### PR TITLE
Rename Prominent Classes

### DIFF
--- a/src/main/java/com/meta/chatbridge/llm/LLMPlugin.java
+++ b/src/main/java/com/meta/chatbridge/llm/LLMPlugin.java
@@ -9,10 +9,10 @@
 package com.meta.chatbridge.llm;
 
 import com.meta.chatbridge.message.Message;
-import com.meta.chatbridge.message.MessageStack;
+import com.meta.chatbridge.message.ThreadState;
 import java.io.IOException;
 
 public interface LLMPlugin<T extends Message> {
 
-  T handle(MessageStack<T> messageStack) throws IOException;
+  T handle(ThreadState<T> threadState) throws IOException;
 }

--- a/src/main/java/com/meta/chatbridge/message/Message.java
+++ b/src/main/java/com/meta/chatbridge/message/Message.java
@@ -31,14 +31,14 @@ public interface Message {
     SYSTEM
   }
 
-  static Identifier conversationId(Identifier id1, Identifier id2) {
+  static Identifier threadId(Identifier id1, Identifier id2) {
     if (id1.compareTo(id2) <= 0) {
       return Identifier.from(id1.toString() + '|' + id2);
     }
     return Identifier.from(id2.toString() + '|' + id1);
   }
 
-  default Identifier conversationId() {
-    return conversationId(senderId(), recipientId());
+  default Identifier threadId() {
+    return threadId(senderId(), recipientId());
   }
 }

--- a/src/main/java/com/meta/chatbridge/message/MessageStack.java
+++ b/src/main/java/com/meta/chatbridge/message/MessageStack.java
@@ -32,8 +32,8 @@ public class MessageStack<T extends Message> {
     Objects.requireNonNull(newMessage);
     messageFactory = old.messageFactory;
     Preconditions.checkArgument(
-        old.tail().conversationId().equals(newMessage.conversationId()),
-        "all messages in a stack must have the same conversation id");
+        old.tail().threadId().equals(newMessage.threadId()),
+        "all messages in a stack must have the same thread id");
     List<T> messages = old.messages;
     if (newMessage.timestamp().isBefore(old.tail().timestamp())) {
       this.messages =

--- a/src/main/java/com/meta/chatbridge/message/ThreadState.java
+++ b/src/main/java/com/meta/chatbridge/message/ThreadState.java
@@ -17,23 +17,23 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class MessageStack<T extends Message> {
+public class ThreadState<T extends Message> {
   private final List<T> messages;
   private final MessageFactory<T> messageFactory;
 
-  private MessageStack(T message) {
+  private ThreadState(T message) {
     Objects.requireNonNull(message);
     this.messages = ImmutableList.of(message);
     messageFactory = MessageFactory.instance(message);
   }
 
   /** Constructor that exists to support the with method */
-  private MessageStack(MessageStack<T> old, T newMessage) {
+  private ThreadState(ThreadState<T> old, T newMessage) {
     Objects.requireNonNull(newMessage);
     messageFactory = old.messageFactory;
     Preconditions.checkArgument(
         old.tail().threadId().equals(newMessage.threadId()),
-        "all messages in a stack must have the same thread id");
+        "all messages in a thread must have the same thread id");
     List<T> messages = old.messages;
     if (newMessage.timestamp().isBefore(old.tail().timestamp())) {
       this.messages =
@@ -46,11 +46,11 @@ public class MessageStack<T extends Message> {
 
     Preconditions.checkArgument(
         old.userId().equals(userId()) && old.botId().equals(botId()),
-        "userId and botId not consistent with this message stack");
+        "userId and botId not consistent with this thread state");
   }
 
-  public static <T extends Message> MessageStack<T> of(T message) {
-    return new MessageStack<>(message);
+  public static <T extends Message> ThreadState<T> of(T message) {
+    return new ThreadState<>(message);
   }
 
   public Identifier userId() {
@@ -78,8 +78,8 @@ public class MessageStack<T extends Message> {
     return messageFactory.newMessage(timestamp, message, userId(), botId(), instanceId, Role.USER);
   }
 
-  public MessageStack<T> with(T message) {
-    return new MessageStack<>(this, message);
+  public ThreadState<T> with(T message) {
+    return new ThreadState<>(this, message);
   }
 
   public List<T> messages() {

--- a/src/main/java/com/meta/chatbridge/store/ChatStore.java
+++ b/src/main/java/com/meta/chatbridge/store/ChatStore.java
@@ -9,7 +9,7 @@
 package com.meta.chatbridge.store;
 
 import com.meta.chatbridge.message.Message;
-import com.meta.chatbridge.message.MessageStack;
+import com.meta.chatbridge.message.ThreadState;
 
 /**
  * This class is in charge of both maintaining a chat history and managing a queue of conversations
@@ -22,5 +22,5 @@ import com.meta.chatbridge.message.MessageStack;
  */
 public interface ChatStore<T extends Message> {
 
-  MessageStack<T> add(T message);
+  ThreadState<T> add(T message);
 }

--- a/src/main/java/com/meta/chatbridge/store/MemoryStore.java
+++ b/src/main/java/com/meta/chatbridge/store/MemoryStore.java
@@ -34,7 +34,7 @@ public class MemoryStore<T extends Message> implements ChatStore<T> {
     return this.store
         .asMap()
         .compute(
-            message.conversationId(),
+            message.threadId(),
             (k, v) -> {
               if (v == null) {
                 return MessageStack.of(message);

--- a/src/main/java/com/meta/chatbridge/store/MemoryStore.java
+++ b/src/main/java/com/meta/chatbridge/store/MemoryStore.java
@@ -12,32 +12,32 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.meta.chatbridge.Identifier;
 import com.meta.chatbridge.message.Message;
-import com.meta.chatbridge.message.MessageStack;
+import com.meta.chatbridge.message.ThreadState;
 import java.time.Duration;
 
 public class MemoryStore<T extends Message> implements ChatStore<T> {
-  private final Cache<Identifier, MessageStack<T>> store;
+  private final Cache<Identifier, ThreadState<T>> store;
 
   MemoryStore(MemoryStoreConfig config) {
     this.store =
         CacheBuilder.newBuilder()
             .expireAfterWrite(Duration.ofHours(config.storageDurationHours()))
             .maximumWeight((long) (config.storageCapacityMb() * Math.pow(2, 20))) // megabytes
-            .<Identifier, MessageStack<T>>weigher(
+            .<Identifier, ThreadState<T>>weigher(
                 (k, v) ->
                     v.messages().stream().map(m -> m.message().length()).reduce(0, Integer::sum))
             .build();
   }
 
   @Override
-  public MessageStack<T> add(T message) {
+  public ThreadState<T> add(T message) {
     return this.store
         .asMap()
         .compute(
             message.threadId(),
             (k, v) -> {
               if (v == null) {
-                return MessageStack.of(message);
+                return ThreadState.of(message);
               }
               return v.with(message);
             });

--- a/src/test/java/com/meta/chatbridge/message/FBMessageHandlerTest.java
+++ b/src/test/java/com/meta/chatbridge/message/FBMessageHandlerTest.java
@@ -214,7 +214,7 @@ public class FBMessageHandlerTest {
           .isEqualTo(0); // make sure the message wasn't processed and stored
       assertThat(requests).hasSize(0);
     } else {
-      MessageStack<FBMessage> stack = llmHandler.take(500);
+      ThreadState<FBMessage> thread = llmHandler.take(500);
       JsonNode messageObject = PARSED_SAMPLE_MESSAGE.get("entry").get(0).get("messaging").get(0);
       String messageText = messageObject.get("message").get("text").textValue();
       String mid = messageObject.get("message").get("mid").textValue();
@@ -222,7 +222,7 @@ public class FBMessageHandlerTest {
           Identifier.from(messageObject.get("recipient").get("id").textValue());
       Identifier senderId = Identifier.from(messageObject.get("sender").get("id").textValue());
       Instant timestamp = Instant.ofEpochMilli(messageObject.get("timestamp").longValue());
-      assertThat(stack.messages())
+      assertThat(thread.messages())
           .hasSize(1)
           .allSatisfy(m -> assertThat(m.message()).isEqualTo(messageText))
           .allSatisfy(m -> assertThat(m.instanceId().toString()).isEqualTo(mid))

--- a/src/test/java/com/meta/chatbridge/message/MessageTest.java
+++ b/src/test/java/com/meta/chatbridge/message/MessageTest.java
@@ -17,14 +17,14 @@ import org.junit.jupiter.api.Test;
 class MessageTest {
 
   @Test
-  void conversationId() {
+  void threadId() {
     Instant timestamp = Instant.now();
     Identifier id0 = Identifier.from("0");
     Identifier id1 = Identifier.from("1");
     Identifier id2 = Identifier.from("2");
     Message message = new FBMessage(timestamp, id0, id1, id2, "", Message.Role.ASSISTANT);
     Message response = new FBMessage(timestamp, id0, id2, id1, "", Message.Role.ASSISTANT);
-    assertThat(message.conversationId()).isEqualTo(response.conversationId());
+    assertThat(message.threadId()).isEqualTo(response.threadId());
 
     message =
         new FBMessage(
@@ -42,6 +42,6 @@ class MessageTest {
             Identifier.from("234"),
             "",
             Message.Role.ASSISTANT);
-    assertThat(message.conversationId()).isNotEqualTo(response.conversationId());
+    assertThat(message.threadId()).isNotEqualTo(response.threadId());
   }
 }

--- a/src/test/java/com/meta/chatbridge/store/MemoryStoreTest.java
+++ b/src/test/java/com/meta/chatbridge/store/MemoryStoreTest.java
@@ -28,16 +28,16 @@ class MemoryStoreTest {
     FBMessage message =
         messageFactory.newMessage(
             Instant.now(), "", senderId, recipientId, Identifier.random(), Message.Role.SYSTEM);
-    MessageStack<FBMessage> stack = memoryStore.add(message);
+    ThreadState<FBMessage> thread = memoryStore.add(message);
     assertThat(memoryStore.size()).isEqualTo(1);
-    assertThat(stack.messages()).hasSize(1).contains(message);
+    assertThat(thread.messages()).hasSize(1).contains(message);
 
     FBMessage message2 =
         messageFactory.newMessage(
             Instant.now(), "", recipientId, senderId, Identifier.random(), Message.Role.USER);
-    stack = memoryStore.add(message2);
+    thread = memoryStore.add(message2);
     assertThat(memoryStore.size()).isEqualTo(1);
-    assertThat(stack.messages()).hasSize(2).contains(message, message2);
+    assertThat(thread.messages()).hasSize(2).contains(message, message2);
 
     FBMessage message3 =
         messageFactory.newMessage(
@@ -47,8 +47,8 @@ class MemoryStoreTest {
             Identifier.random(),
             Identifier.random(),
             Message.Role.SYSTEM);
-    stack = memoryStore.add(message3);
+    thread = memoryStore.add(message3);
     assertThat(memoryStore.size()).isEqualTo(2);
-    assertThat(stack.messages()).hasSize(1).contains(message3);
+    assertThat(thread.messages()).hasSize(1).contains(message3);
   }
 }

--- a/src/test/java/com/meta/chatbridge/store/ThreadStateTest.java
+++ b/src/test/java/com/meta/chatbridge/store/ThreadStateTest.java
@@ -14,11 +14,11 @@ import com.meta.chatbridge.Identifier;
 import com.meta.chatbridge.message.FBMessage;
 import com.meta.chatbridge.message.Message;
 import com.meta.chatbridge.message.MessageFactory;
-import com.meta.chatbridge.message.MessageStack;
+import com.meta.chatbridge.message.ThreadState;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
-class MessageStackTest {
+class ThreadStateTest {
 
   private static final MessageFactory<FBMessage> FACTORY = MessageFactory.instance(FBMessage.class);
 
@@ -34,14 +34,14 @@ class MessageStackTest {
             Identifier.random(),
             Message.Role.USER);
 
-    MessageStack<FBMessage> ms = MessageStack.of(message1);
+    ThreadState<FBMessage> ms = ThreadState.of(message1);
     FBMessage message2 = ms.newMessageFromBot(start.plusSeconds(1), "other sample message");
     ms = ms.with(message2);
     assertThat(ms.messages()).hasSize(2);
     assertThat(ms.messages().get(0)).isSameAs(message1);
     assertThat(ms.messages().get(1)).isSameAs(message2);
 
-    ms = MessageStack.of(message1);
+    ms = ThreadState.of(message1);
     assertThat(ms.messages()).hasSize(1);
     ms = ms.with(message2);
     assertThat(ms.messages()).hasSize(2);
@@ -60,7 +60,7 @@ class MessageStackTest {
             Identifier.random(),
             Identifier.random(),
             Message.Role.USER);
-    MessageStack<FBMessage> ms = MessageStack.of(message2);
+    ThreadState<FBMessage> ms = ThreadState.of(message2);
 
     FBMessage message1 = ms.newMessageFromBot(start.minusSeconds(1), "other sample message");
 
@@ -68,7 +68,7 @@ class MessageStackTest {
     assertThat(ms.messages().get(0)).isSameAs(message1);
     assertThat(ms.messages().get(1)).isSameAs(message2);
 
-    ms = MessageStack.of(message2);
+    ms = ThreadState.of(message2);
     assertThat(ms.messages()).hasSize(1);
     ms = ms.with(message1);
     assertThat(ms.messages()).hasSize(2);
@@ -88,7 +88,7 @@ class MessageStackTest {
             Identifier.random(),
             Message.Role.USER);
 
-    MessageStack<FBMessage> ms = MessageStack.of(message1);
+    ThreadState<FBMessage> ms = ThreadState.of(message1);
     FBMessage message2 =
         FACTORY.newMessage(
             start,
@@ -98,7 +98,7 @@ class MessageStackTest {
             Identifier.random(),
             Message.Role.ASSISTANT);
 
-    final MessageStack<FBMessage> finalMs = ms;
+    final ThreadState<FBMessage> finalMs = ms;
     assertThatCode(() -> finalMs.with(message2)).doesNotThrowAnyException();
     assertThatCode(() -> finalMs.with(finalMs.newMessageFromBot(start, "")))
         .doesNotThrowAnyException();
@@ -116,7 +116,7 @@ class MessageStackTest {
             Identifier.random(),
             Message.Role.USER);
 
-    MessageStack<FBMessage> finalMs1 = ms;
+    ThreadState<FBMessage> finalMs1 = ms;
     assertThatThrownBy(() -> finalMs1.with(mDifferentSenderId))
         .isInstanceOf(IllegalArgumentException.class);
 


### PR DESCRIPTION
`ConversationId` -> `ThreadId`: conversation id has a specific meaning in Whatsapp that does not align with the usage here so I'm avoiding some confusion early

`MessageStack` -> `ThreadState`: After presenting this code it was very clear that message stack was a confusing name, I think this better represents the use case too