### PR TITLE
Dropyacht: dynamic source page

### DIFF
--- a/src/main/java/com/meta/cp4m/message/FBMessage.java
+++ b/src/main/java/com/meta/cp4m/message/FBMessage.java
@@ -10,6 +10,7 @@ package com.meta.cp4m.message;
 
 import com.meta.cp4m.Identifier;
 import java.time.Instant;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public record FBMessage(
     Instant timestamp,
@@ -17,5 +18,17 @@ public record FBMessage(
     Identifier senderId,
     Identifier recipientId,
     String message,
-    Role role)
-    implements Message {}
+    Role role,
+    @Nullable String accessToken)
+    implements Message {
+
+  public FBMessage(
+      Instant timestamp,
+      Identifier instanceId,
+      Identifier senderId,
+      Identifier recipientId,
+      String message,
+      Role role) {
+    this(timestamp, instanceId, senderId, recipientId, message, role, null);
+  }
+}

--- a/src/main/java/com/meta/cp4m/message/FBMessageHandler.java
+++ b/src/main/java/com/meta/cp4m/message/FBMessageHandler.java
@@ -158,12 +158,14 @@ public class FBMessageHandler implements MessageHandler<FBMessage> {
   @Override
   public void respond(FBMessage message) throws IOException {
     List<String> chunkedText = CHUNKER.chunks(message.message()).toList();
+    String accessToken = message.accessToken() == null ? this.accessToken : message.accessToken();
     for (String text : chunkedText) {
-      send(text, message.recipientId(), message.senderId());
+      send(text, message.recipientId(), message.senderId(), accessToken);
     }
   }
 
-  private void send(String message, Identifier recipient, Identifier sender) throws IOException {
+  private void send(String message, Identifier recipient, Identifier sender, String accessToken)
+      throws IOException {
     URI url;
     ObjectNode body = MAPPER.createObjectNode();
     body.put("messaging_type", "RESPONSE").putObject("recipient").put("id", recipient.toString());

--- a/src/main/java/com/meta/cp4m/message/FBMessengerConfig.java
+++ b/src/main/java/com/meta/cp4m/message/FBMessengerConfig.java
@@ -10,10 +10,8 @@ package com.meta.cp4m.message;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import org.checkerframework.checker.nullness.qual.Nullable;
-
-import java.util.Optional;
 import java.util.UUID;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class FBMessengerConfig implements HandlerConfig {
 
@@ -21,14 +19,14 @@ public class FBMessengerConfig implements HandlerConfig {
     private final String verifyToken;
     private final String appSecret;
     private final String pageAccessToken;
-    private final @Nullable String connectedFacebookPageForInstagram;
+  private final boolean instagramMode;
 
-    private FBMessengerConfig(
-            @JsonProperty("name") String name,
-            @JsonProperty("verify_token") String verifyToken,
-            @JsonProperty("app_secret") String appSecret,
-            @JsonProperty("page_access_token") String pageAccessToken,
-            @JsonProperty("connected_facebook_page_for_instagram") @Nullable String connectedFacebookPageForInstagram) {
+  private FBMessengerConfig(
+      @JsonProperty("name") String name,
+      @JsonProperty("verify_token") String verifyToken,
+      @JsonProperty("app_secret") String appSecret,
+      @JsonProperty("page_access_token") String pageAccessToken,
+      @JsonProperty("instagram_mode") @Nullable Boolean instagramMode) {
 
         Preconditions.checkArgument(name != null && !name.isBlank(), "name cannot be blank");
         Preconditions.checkArgument(
@@ -42,19 +40,20 @@ public class FBMessengerConfig implements HandlerConfig {
         this.verifyToken = verifyToken;
         this.appSecret = appSecret;
         this.pageAccessToken = pageAccessToken;
-        this.connectedFacebookPageForInstagram = connectedFacebookPageForInstagram;
+    this.instagramMode = instagramMode != null && instagramMode;
     }
 
-    public static FBMessengerConfig of(String verifyToken, String appSecret, String pageAccessToken, @Nullable String connectedFacebookPageForInstagram) {
-        // human readability of the name only matters when it's coming from a config
-        return new FBMessengerConfig(
-                UUID.randomUUID().toString(), verifyToken, appSecret, pageAccessToken, connectedFacebookPageForInstagram);
+  public static FBMessengerConfig of(
+      String verifyToken, String appSecret, String pageAccessToken, boolean instagramMode) {
+    // human readability of the name only matters when it's coming from a config
+    return new FBMessengerConfig(
+        UUID.randomUUID().toString(), verifyToken, appSecret, pageAccessToken, instagramMode);
     }
 
     public static FBMessengerConfig of(String verifyToken, String appSecret, String pageAccessToken) {
-        // human readability of the name only matters when it's coming from a config
-        return new FBMessengerConfig(
-                UUID.randomUUID().toString(), verifyToken, appSecret, pageAccessToken, null);
+    // human readability of the name only matters when it's coming from a config
+    return new FBMessengerConfig(
+        UUID.randomUUID().toString(), verifyToken, appSecret, pageAccessToken, false);
     }
 
     @Override
@@ -79,7 +78,7 @@ public class FBMessengerConfig implements HandlerConfig {
         return pageAccessToken;
     }
 
-    public Optional<String> connectedFacebookPageForInstagram() {
-        return Optional.ofNullable(connectedFacebookPageForInstagram);
+  public boolean instagramMode() {
+    return instagramMode;
     }
 }

--- a/src/test/java/com/meta/cp4m/message/FBMessageHandlerTest.java
+++ b/src/test/java/com/meta/cp4m/message/FBMessageHandlerTest.java
@@ -330,9 +330,9 @@ public class FBMessageHandlerTest {
 
     FBMessageHandler messageHandler;
     if (isInstagram) {
-      messageHandler = new FBMessageHandler("0", token, secret, pageId.toString());
+      messageHandler = new FBMessageHandler("0", token, secret, true);
     } else {
-      messageHandler = new FBMessageHandler("0", token, secret);
+      messageHandler = new FBMessageHandler("0", token, secret, false);
     }
     DummyLLMPlugin<FBMessage> llmHandler = new DummyLLMPlugin<>("this is a dummy message");
     MemoryStore<FBMessage> memoryStore = MemoryStoreConfig.of(1, 1).toStore();

--- a/src/test/java/com/meta/cp4m/message/FBMessengerConfigTest.java
+++ b/src/test/java/com/meta/cp4m/message/FBMessengerConfigTest.java
@@ -49,7 +49,12 @@ class FBMessengerConfigTest {
               .required(true)
               .validValues("123")
               .invalidValues("", " ")
-              .getter(FBMessengerConfig::pageAccessToken));
+              .getter(FBMessengerConfig::pageAccessToken),
+          ConfigParamTestSpec.of(FBMessengerConfig.class, "instagram_mode")
+              .required(false)
+              .validValues(true, false)
+              .invalidValues("anything that's not a boolean", 3.14)
+              .getter(FBMessengerConfig::instagramMode));
 
   static Stream<Named<ConfigParamTestSpec<FBMessengerConfig>>> required() {
     return PARAMS.stream().filter(ConfigParamTestSpec::required).map(p -> Named.of(p.name(), p));
@@ -94,6 +99,12 @@ class FBMessengerConfigTest {
     for (JsonNode invalidValue : param.invalidValues()) {
       config.set(param.name(), invalidValue);
       assertThatThrownBy(() -> mapper.convertValue(config, FBMessengerConfig.class))
+          .withFailMessage(
+              "expecting the value of '"
+                  + invalidValue
+                  + "' to be invalid for field '"
+                  + param.name()
+                  + "'")
           .isInstanceOf(IllegalArgumentException.class);
     }
   }


### PR DESCRIPTION
The FBMessengerHandler handles both Instagram and FBMessenger, to use the handler for instagram set the value `instagram_mode=true`

here is an example with instagram mode set in the Messenger Handler
```toml
port = 8080

[[plugins]]
name = "hf_test"
type = "hugging_face"
endpoint = "https://example.com"
token_limit = 1000
api_key = "<your api_token here>"

[[stores]]
name = "memory_test"
type = "memory"
storage_duration_hours = 1
storage_capacity_mbs = 1

[[handlers]]
type = "messenger"
name = "messenger_test"
instagram_mode = true
verify_token = "<your verification token here>"
app_secret = "<your verification app secret here>"
page_access_token = "<your page access token here>"

[[services]]
webhook_path = "/messenger"
plugin = "openai_test"
store = "memory_test"
handler = "messenger_test"
```


To dynamically set from the plugin the page and access token fields set the corresponding values in the FBMessage. This is a bit of a hack for the time being so your plugin will need to only support FBMessage as an input, so you can use the constructors in FBMessage to create FBMessage objects. For Instagram make sure that the page id is the corresponding **Facebook** page.
