### PR TITLE
[Website] Fixed broken links on home page and footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -86,16 +86,6 @@ const config = {
         links: [
           {
             title: 'Learn',
-            items: [
-              {
-                label: 'Style Guide',
-                to: 'docs/',
-              },
-              {
-                label: 'Second Doc',
-                to: 'docs/doc2',
-              },
-            ],
           },
           {
             title: 'More',
@@ -137,7 +127,7 @@ const config = {
           alt: 'Meta Open Source Logo',
           // This default includes a positive & negative version, allowing for
           // appropriate use depending on your site's style.
-          src: '/img/meta_opensource_logo_negative.svg',
+          src: 'CP4M/img/meta_opensource_logo_negative.svg',
           href: 'https://opensource.fb.com',
         },
         // Please do not remove the credits, help to publicize Docusaurus :)

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -80,7 +80,7 @@ export default function Home() {
                 'button button--outline button--secondary button--lg',
                 styles.getStarted,
               )}
-              to={useBaseUrl('docs/')}>
+              to={useBaseUrl('docs/intro')}>
               Get Started
             </Link>
           </div>


### PR DESCRIPTION
Fixed broken links navigating to non-existent docs/, docs/doc, docs/doc2 pages. Also, fixed the Meta Open Source logo image link by adding "CP4M/" to the start of the URL.

**Test Plan**
`npm run build`

<img width="542" alt="Screenshot 2024-02-28 at 5 48 12 PM" src="https://github.com/facebookincubator/CP4M/assets/17011763/2167de27-f613-4b34-99cf-aec88424118d">

Successful build

Current main branch leads to this error:
<img width="835" alt="Screenshot 2024-02-28 at 5 51 40 PM" src="https://github.com/facebookincubator/CP4M/assets/17011763/fdcb031b-84a7-48d5-8117-4264ca5240a8">


