### PR TITLE
Adding a Null Chat Store

### DIFF
--- a/src/main/java/com/meta/cp4m/ServiceConfiguration.java
+++ b/src/main/java/com/meta/cp4m/ServiceConfiguration.java
@@ -11,26 +11,28 @@ package com.meta.cp4m;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.util.Objects;
 
 public class ServiceConfiguration {
   private final String webhookPath;
   private final String handler;
-  private final String store;
+  private final @Nullable String store;
   private final String plugin;
 
   @JsonCreator
   ServiceConfiguration(
       @JsonProperty("webhook_path") String webhookPath,
       @JsonProperty("handler") String handler,
-      @JsonProperty("store") String store,
+      @JsonProperty("store") @Nullable String store,
       @JsonProperty("plugin") String plugin) {
     Preconditions.checkArgument(
         webhookPath != null && webhookPath.startsWith("/"),
         "webhook_path must be present and it must start with a forward slash (/)");
     this.webhookPath = webhookPath;
     this.handler = Objects.requireNonNull(handler, "handler must be present");
-    this.store = Objects.requireNonNull(store, "store must be present");
+    this.store = store;
     this.plugin = Objects.requireNonNull(plugin, "plugin must be present");
   }
 
@@ -42,6 +44,7 @@ public class ServiceConfiguration {
     return handler;
   }
 
+  @Nullable
   public String store() {
     return store;
   }

--- a/src/main/java/com/meta/cp4m/ServiceConfiguration.java
+++ b/src/main/java/com/meta/cp4m/ServiceConfiguration.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
-
 import java.util.Objects;
 
 public class ServiceConfiguration {

--- a/src/main/java/com/meta/cp4m/configuration/RootConfiguration.java
+++ b/src/main/java/com/meta/cp4m/configuration/RootConfiguration.java
@@ -66,9 +66,9 @@ public class RootConfiguration {
             .collect(Collectors.toUnmodifiableMap(LLMConfig::name, Function.identity()));
 
     Preconditions.checkArgument(stores.size() == stores.stream()
-                .map(StoreConfig::name)
-                .collect(Collectors.toUnmodifiableSet())
-                .size(),
+        .map(StoreConfig::name)
+        .collect(Collectors.toUnmodifiableSet())
+        .size(),
         "all store names must be unique");
     this.stores =
             stores.stream()
@@ -89,7 +89,7 @@ public class RootConfiguration {
       Preconditions.checkArgument(
           this.plugins.containsKey(s.plugin()), s.plugin() + " must be the name of a plugin");
       Preconditions.checkArgument( s.store() == null || this.stores.containsKey(s.store()),
-              s.store() + " must be the name of a store");
+            s.store() + " must be the name of a store");
       Preconditions.checkArgument(
           this.handlers.containsKey(s.handler()), s.handler() + " must be the name of a handler");
     }

--- a/src/main/java/com/meta/cp4m/configuration/RootConfiguration.java
+++ b/src/main/java/com/meta/cp4m/configuration/RootConfiguration.java
@@ -20,6 +20,7 @@ import com.meta.cp4m.message.HandlerConfig;
 import com.meta.cp4m.message.Message;
 import com.meta.cp4m.message.MessageHandler;
 import com.meta.cp4m.store.ChatStore;
+import com.meta.cp4m.store.NullStore;
 import com.meta.cp4m.store.StoreConfig;
 import java.util.Collection;
 import java.util.Collections;
@@ -64,16 +65,14 @@ public class RootConfiguration {
         plugins.stream()
             .collect(Collectors.toUnmodifiableMap(LLMConfig::name, Function.identity()));
 
-    Preconditions.checkArgument(
-        stores.size()
-            == stores.stream()
+    Preconditions.checkArgument(stores.size() == stores.stream()
                 .map(StoreConfig::name)
                 .collect(Collectors.toUnmodifiableSet())
                 .size(),
         "all store names must be unique");
     this.stores =
-        stores.stream()
-            .collect(Collectors.toUnmodifiableMap(StoreConfig::name, Function.identity()));
+            stores.stream()
+                    .collect(Collectors.toUnmodifiableMap(StoreConfig::name, Function.identity()));
 
     Preconditions.checkArgument(
         handlers.size()
@@ -89,8 +88,8 @@ public class RootConfiguration {
     for (ServiceConfiguration s : services) {
       Preconditions.checkArgument(
           this.plugins.containsKey(s.plugin()), s.plugin() + " must be the name of a plugin");
-      Preconditions.checkArgument(
-          this.stores.containsKey(s.store()), s.store() + " must be the name of a store");
+      Preconditions.checkArgument( s.store() == null || this.stores.containsKey(s.store()),
+              s.store() + " must be the name of a store");
       Preconditions.checkArgument(
           this.handlers.containsKey(s.handler()), s.handler() + " must be the name of a handler");
     }
@@ -118,9 +117,14 @@ public class RootConfiguration {
   }
 
   private <T extends Message> Service<T> createService(
-      MessageHandler<T> handler, ServiceConfiguration serviceConfig) {
+          MessageHandler<T> handler, ServiceConfiguration serviceConfig) {
     LLMPlugin<T> plugin = plugins.get(serviceConfig.plugin()).toPlugin();
-    ChatStore<T> store = stores.get(serviceConfig.store()).toStore();
+    ChatStore<T> store;
+    if(serviceConfig.store() != null){
+      store = stores.get(serviceConfig.store()).toStore();
+    } else {
+      store = new NullStore<T>();
+    }
     return new Service<>(store, handler, plugin, serviceConfig.webhookPath());
   }
 

--- a/src/main/java/com/meta/cp4m/store/NullStore.java
+++ b/src/main/java/com/meta/cp4m/store/NullStore.java
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.meta.cp4m.store;
+
+import com.google.common.cache.Cache;
+import com.meta.cp4m.Identifier;
+import com.meta.cp4m.message.Message;
+import com.meta.cp4m.message.ThreadState;
+
+import java.util.List;
+
+/**
+ * This class is a default store that does not persist any data.
+ *
+ * @param <T> the type of message being passed stored
+ */
+public class NullStore<T extends Message> implements ChatStore<T> {
+
+    @Override
+    public ThreadState<T> add(T message) {
+        return ThreadState.of(message);
+    }
+
+    @Override
+    public long size() {
+        return 0;
+    }
+
+    @Override
+    public List<ThreadState<T>> list() {
+        return List.of();
+    }
+}

--- a/src/test/java/com/meta/cp4m/store/NullStoreTest.java
+++ b/src/test/java/com/meta/cp4m/store/NullStoreTest.java
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.meta.cp4m.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.meta.cp4m.Identifier;
+import com.meta.cp4m.message.*;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class NullStoreStoreTest {
+
+    @Test
+    void test() {
+        Identifier senderId = Identifier.random();
+        Identifier recipientId = Identifier.random();
+
+        MessageFactory<FBMessage> messageFactory = MessageFactory.instance(FBMessage.class);
+        NullStore<FBMessage> nullStore = new NullStore<>();
+
+        assertThat(nullStore.size()).isEqualTo(0);
+        FBMessage message =
+                messageFactory.newMessage(
+                        Instant.now(), "", senderId, recipientId, Identifier.random(), Message.Role.ASSISTANT);
+        ThreadState<FBMessage> thread = nullStore.add(message);
+        assertThat(nullStore.size()).isEqualTo(0);
+        assertThat(thread.messages()).hasSize(1).contains(message);
+
+        FBMessage message2 =
+                messageFactory.newMessage(
+                        Instant.now(), "", recipientId, senderId, Identifier.random(), Message.Role.USER);
+        thread = nullStore.add(message2);
+        assertThat(nullStore.size()).isEqualTo(0);
+        assertThat(thread.messages()).hasSize(1);
+
+        FBMessage message3 =
+                messageFactory.newMessage(
+                        Instant.now(),
+                        "",
+                        Identifier.random(),
+                        Identifier.random(),
+                        Identifier.random(),
+                        Message.Role.USER);
+        thread = nullStore.add(message3);
+        assertThat(nullStore.size()).isEqualTo(0);
+        assertThat(thread.messages()).hasSize(1).contains(message3);
+    }
+}


### PR DESCRIPTION
BSPs typically don't need to have the chat conversation stored, for this use case, building a new Null ChatStore that doesn't store any messages.

Key changes:
- new NullStore class
- Store service is now nullable
- RootConfig creates Null/regular store depending on config file

Tests:
- TOML + WA use case with no store defined
- Instantiating NullStore and message exchange

