### PR TITLE
Adding appsecret_proof to the API calls for WA and FBMessenger

### DIFF
--- a/src/main/java/com/meta/cp4m/message/FBMessageHandler.java
+++ b/src/main/java/com/meta/cp4m/message/FBMessageHandler.java
@@ -73,7 +73,7 @@ public class FBMessageHandler implements MessageHandler<FBMessage> {
     this.appSecret = appSecret;
     this.accessToken = pageAccessToken;
     this.connectedFacebookPageForInstagram = connectedFacebookPageForInstagram;
-    this.appSecretProof = MetaHandlerUtils.hmac(accessToken,appSecret);
+    this.appSecretProof = MetaHandlerUtils.hmac(accessToken, appSecret);
   }
 
   public FBMessageHandler(String verifyToken, String pageAccessToken, String appSecret) {
@@ -81,14 +81,14 @@ public class FBMessageHandler implements MessageHandler<FBMessage> {
     this.appSecret = appSecret;
     this.accessToken = pageAccessToken;
     this.connectedFacebookPageForInstagram = null;
-    this.appSecretProof = MetaHandlerUtils.hmac(accessToken,appSecret);
+    this.appSecretProof = MetaHandlerUtils.hmac(accessToken, appSecret);
   }
 
   FBMessageHandler(FBMessengerConfig config) {
     this.verifyToken = config.verifyToken();
     this.appSecret = config.appSecret();
     this.accessToken = config.pageAccessToken();
-    this.appSecretProof = MetaHandlerUtils.hmac(accessToken,appSecret);
+    this.appSecretProof = MetaHandlerUtils.hmac(accessToken, appSecret);
     this.connectedFacebookPageForInstagram =
         config.connectedFacebookPageForInstagram().isPresent()
             ? config.connectedFacebookPageForInstagram().get()
@@ -188,7 +188,7 @@ public class FBMessageHandler implements MessageHandler<FBMessage> {
                           ? sender
                           : Identifier.from(connectedFacebookPageForInstagram)))
               .addParameter("access_token", accessToken)
-                  .addParameter("appsecret_proof", appSecretProof)
+              .addParameter("appsecret_proof", appSecretProof)
               .build();
     } catch (JsonProcessingException | URISyntaxException e) {
       // should be impossible

--- a/src/main/java/com/meta/cp4m/message/FBMessageHandler.java
+++ b/src/main/java/com/meta/cp4m/message/FBMessageHandler.java
@@ -44,6 +44,7 @@ public class FBMessageHandler implements MessageHandler<FBMessage> {
   private final String appSecret;
 
   private final String accessToken;
+  private final String appSecretProof;
   private final @Nullable String connectedFacebookPageForInstagram;
 
   private final Deduplicator<Identifier> messageDeduplicator = new Deduplicator<>(10_000);
@@ -72,6 +73,7 @@ public class FBMessageHandler implements MessageHandler<FBMessage> {
     this.appSecret = appSecret;
     this.accessToken = pageAccessToken;
     this.connectedFacebookPageForInstagram = connectedFacebookPageForInstagram;
+    this.appSecretProof = MetaHandlerUtils.hmac(accessToken,appSecret);
   }
 
   public FBMessageHandler(String verifyToken, String pageAccessToken, String appSecret) {
@@ -79,12 +81,14 @@ public class FBMessageHandler implements MessageHandler<FBMessage> {
     this.appSecret = appSecret;
     this.accessToken = pageAccessToken;
     this.connectedFacebookPageForInstagram = null;
+    this.appSecretProof = MetaHandlerUtils.hmac(accessToken,appSecret);
   }
 
   FBMessageHandler(FBMessengerConfig config) {
     this.verifyToken = config.verifyToken();
     this.appSecret = config.appSecret();
     this.accessToken = config.pageAccessToken();
+    this.appSecretProof = MetaHandlerUtils.hmac(accessToken,appSecret);
     this.connectedFacebookPageForInstagram =
         config.connectedFacebookPageForInstagram().isPresent()
             ? config.connectedFacebookPageForInstagram().get()
@@ -184,6 +188,7 @@ public class FBMessageHandler implements MessageHandler<FBMessage> {
                           ? sender
                           : Identifier.from(connectedFacebookPageForInstagram)))
               .addParameter("access_token", accessToken)
+                  .addParameter("appsecret_proof", appSecretProof)
               .build();
     } catch (JsonProcessingException | URISyntaxException e) {
       // should be impossible

--- a/src/main/java/com/meta/cp4m/message/WAMessageHandler.java
+++ b/src/main/java/com/meta/cp4m/message/WAMessageHandler.java
@@ -53,6 +53,7 @@ public class WAMessageHandler implements MessageHandler<WAMessage> {
   private final String appSecret;
   private final String verifyToken;
   private final String accessToken;
+  private final String appSecretProof;
 
   private Function<Identifier, URI> baseURLFactory =
       phoneNumberId -> {
@@ -74,6 +75,7 @@ public class WAMessageHandler implements MessageHandler<WAMessage> {
     this.verifyToken = config.verifyToken();
     this.accessToken = config.accessToken();
     this.appSecret = config.appSecret();
+    this.appSecretProof = MetaHandlerUtils.hmac(accessToken, appSecret);
   }
 
   private List<WAMessage> post(Context ctx, WebhookPayload payload) {
@@ -136,6 +138,7 @@ public class WAMessageHandler implements MessageHandler<WAMessage> {
     bodyString = MAPPER.writeValueAsString(body);
     Request.post(baseURLFactory.apply(sender))
         .setHeader("Authorization", "Bearer " + accessToken)
+        .setHeader("appsecret_proof", appSecretProof)
         .bodyString(bodyString, ContentType.APPLICATION_JSON)
         .execute();
   }
@@ -183,6 +186,7 @@ public class WAMessageHandler implements MessageHandler<WAMessage> {
     try {
       Request.post(baseURLFactory.apply(phoneNumberId))
           .setHeader("Authorization", "Bearer " + accessToken)
+          .setHeader("appsecret_proof", appSecretProof)
           .bodyString(bodyString, ContentType.APPLICATION_JSON)
           .execute();
     } catch (IOException e) {


### PR DESCRIPTION
Introduced `appsecret_proof` as a parameter in the API calls for WhatsApp and Facebook MessengeHandlers

Context - Almost every Graph API call requires an access token. Malicious developers can steal these access tokens and use them to send spam from your app. APIs can be further secured using `appSecretProof` parameter which is a sha256 hash of your access token, using the app secret as the key.

Dev doc - https://developers.facebook.com/docs/graph-api/securing-requests%20/