### PR TITLE
Fixing log4jv2 errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jacksonVersion>2.15.2</jacksonVersion>
         <junit5Version>5.10.0</junit5Version>
-        <log4j2Version>2.20.0</log4j2Version>
+        <log4j2Version>2.23.1</log4j2Version>
         <systemStubsVersion>2.1.1</systemStubsVersion>
         <custom.jarName>${project.artifactId}-${project.version}</custom.jarName>
     </properties>
@@ -132,7 +132,6 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <minimizeJar>true</minimizeJar>
                             <transformers>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
If a dependency contains log4j2 plugin, a Log4j2Plugins.dat cache file is included in the jar. When the Maven shade plugin is used to merge multiple jars with a Log4j2Plugins.dat file, only one will survive. Without the plugin definitions, following errors are shown on startup.

```
$ docker run -v /tmp/cp4m:/tmp/cp4m -e CP4M_CONFIGURATION_FILE=/tmp/cp4m/cp4m.toml -p 8080:8081 cp4m
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
ERROR StatusLogger Unrecognized format specifier [d]
ERROR StatusLogger Unrecognized conversion specifier [d] starting at position 16 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [thread]
ERROR StatusLogger Unrecognized conversion specifier [thread] starting at position 25 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [level]
ERROR StatusLogger Unrecognized conversion specifier [level] starting at position 35 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [logger]
ERROR StatusLogger Unrecognized conversion specifier [logger] starting at position 47 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [msg]
ERROR StatusLogger Unrecognized conversion specifier [msg] starting at position 54 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [n]
ERROR StatusLogger Unrecognized conversion specifier [n] starting at position 56 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [d]
ERROR StatusLogger Unrecognized conversion specifier [d] starting at position 16 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [thread]
ERROR StatusLogger Unrecognized conversion specifier [thread] starting at position 25 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [level]
ERROR StatusLogger Unrecognized conversion specifier [level] starting at position 35 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [logger]
ERROR StatusLogger Unrecognized conversion specifier [logger] starting at position 47 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [msg]
ERROR StatusLogger Unrecognized conversion specifier [msg] starting at position 54 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [n]
ERROR StatusLogger Unrecognized conversion specifier [n] starting at position 56 in conversion pattern.
```

This does not have an official fix from maven or log4jv2 yet. Fixing it by taking out minimize var to not overlap definitions.


Logs after fix--

```
sachinkarve@sachinkarve-mbp CP4M % docker run -v /tmp/cp4m:/tmp/cp4m -e CP4M_CONFIGURATION_FILE=/tmp/cp4m/cp4m.toml -p 8080:8080 cp4m 
{"timeMillis":1715957768907,"thread":"main","level":"INFO","loggerName":"io.javalin.Javalin","message":"Starting Javalin ...","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:08.907+0000"}
{"timeMillis":1715957768957,"thread":"main","level":"INFO","loggerName":"org.eclipse.jetty.server.Server","message":"jetty-11.0.19; built: 2023-12-15T20:54:39.802Z; git: f781e475c8fa9e9c8ce18b1eaa03110d510f905f; jvm 21.0.3+9-LTS","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:08.957+0000"}
{"timeMillis":1715957768986,"thread":"main","level":"INFO","loggerName":"org.eclipse.jetty.server.session.DefaultSessionIdManager","message":"Session workerName=node0","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:08.986+0000"}
{"timeMillis":1715957768993,"thread":"main","level":"INFO","loggerName":"org.eclipse.jetty.server.handler.ContextHandler","message":"Started o.e.j.s.ServletContextHandler@7ae895f1{/,null,AVAILABLE}","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:08.993+0000"}
{"timeMillis":1715957768997,"thread":"main","level":"INFO","loggerName":"org.eclipse.jetty.server.AbstractConnector","message":"Started ServerConnector@fffa36e{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:08.997+0000"}
{"timeMillis":1715957768998,"thread":"main","level":"INFO","loggerName":"org.eclipse.jetty.server.Server","message":"Started Server@20725e24{STARTING}[11.0.19,sto=0] @1012ms","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:08.998+0000"}
{"timeMillis":1715957768998,"thread":"main","level":"INFO","loggerName":"io.javalin.Javalin","message":"\n       __                  ___           _____\n      / /___ __   ______ _/ (_)___      / ___/\n __  / / __ `/ | / / __ `/ / / __ \\    / __ \\\n/ /_/ / /_/ /| |/ / /_/ / / / / / /   / /_/ /\n\\____/\\__,_/ |___/\\__,_/_/_/_/ /_/    \\____/\n\n       https://javalin.io/documentation\n","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:08.998+0000"}
{"timeMillis":1715957768999,"thread":"main","level":"INFO","loggerName":"io.javalin.Javalin","message":"Javalin started in 132ms \\o/","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:08.999+0000"}
{"timeMillis":1715957769002,"thread":"main","level":"INFO","loggerName":"io.javalin.Javalin","message":"Listening on http://localhost:8080/","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:09.002+0000"}
{"timeMillis":1715957769010,"thread":"main","level":"INFO","loggerName":"io.javalin.Javalin","message":"You are running Javalin 6.0.1 (released February 4, 2024. Your Javalin version is 103 days old. Consider checking for a newer version.).","endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","contextMap":{},"threadId":1,"threadPriority":5,"timestamp":"2024-05-17T14:56:09.010+0000"}
```

