### PR TITLE
http headers are case insensitive

### DIFF
--- a/src/main/java/com/meta/cp4m/message/MetaHandlerUtils.java
+++ b/src/main/java/com/meta/cp4m/message/MetaHandlerUtils.java
@@ -88,7 +88,7 @@ class MetaHandlerUtils {
    * @param appSecret app secret corresponding to this app
    */
   static boolean postHeaderValid(Context ctx, String appSecret) {
-    @Nullable String sig = ctx.headerMap().get("X-Hub-Signature-256");
+    @Nullable String sig = ctx.header("X-Hub-Signature-256");
     if (sig == null) {
       return false;
     }

--- a/src/test/java/com/meta/cp4m/message/FBMessageHandlerTest.java
+++ b/src/test/java/com/meta/cp4m/message/FBMessageHandlerTest.java
@@ -137,6 +137,13 @@ public class FBMessageHandlerTest {
                         .addHeader("X-Hub-Signature-256", SAMPLE_MESSAGE_HMAC),
                 true),
             new TestArgument(
+                "valid sample w/ lower case signature header",
+                200,
+                r ->
+                    createMessageRequest(SAMPLE_MESSAGE, r, false)
+                        .addHeader("x-hub-signature-256", SAMPLE_MESSAGE_HMAC),
+                true),
+            new TestArgument(
                 // if this fails the test hmac calculator is flawed
                 "valid sample with hmac calculation",
                 200,


### PR DESCRIPTION
was incorrectly using `headerMap` to extract headers which is case sensitive.