### PR TITLE
give the memory store the ability to truncates threads

### DIFF
--- a/src/main/java/com/meta/cp4m/message/UserData.java
+++ b/src/main/java/com/meta/cp4m/message/UserData.java
@@ -47,6 +47,10 @@ public class UserData {
         newest.phoneNumber != null ? newest.phoneNumber : oldest.phoneNumber);
   }
 
+  Identifier userId() {
+    return userId;
+  }
+
   public Optional<String> phoneNumber() {
     return Optional.ofNullable(phoneNumber);
   }

--- a/src/test/java/com/meta/cp4m/message/WAMessageHandlerTest.java
+++ b/src/test/java/com/meta/cp4m/message/WAMessageHandlerTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class WAMessageHandlerTest {
-
+  static String BODY_TEXT = "this is a text message!@#$%^&*()’";
   static final String VALID =
       """
 {
@@ -63,7 +63,11 @@ class WAMessageHandlerTest {
                 "timestamp": "1504902988",
                 "type": "text",
                 "text": {
-                  "body": "this is a text message"
+                  "body": """
+          + "\""
+          + BODY_TEXT
+          + "\""
+          + """
                 }
               }
             ]
@@ -200,7 +204,7 @@ class WAMessageHandlerTest {
         .hasSize(2)
         .anySatisfy(
             m -> {
-              assertThat(m.message()).isEqualTo("this is a text message");
+              assertThat(m.message()).isEqualTo(BODY_TEXT);
               assertThat(m.instanceId()).isEqualTo(Identifier.from("ABGGFlA5Fpa"));
               assertThat(m.senderId()).isEqualTo(Identifier.from("16315551181"));
               assertThat(m.recipientId()).isEqualTo(Identifier.from("123456123"));

--- a/src/test/java/com/meta/cp4m/plugin/GenericPluginTest.java
+++ b/src/test/java/com/meta/cp4m/plugin/GenericPluginTest.java
@@ -124,7 +124,7 @@ handler = "messenger_test"
                 ThreadState.of(
                     f.newMessage(
                         messageTime,
-                        new Payload.Text("hello world!"),
+                        new Payload.Text("hello world!'\"!@#$%^&*()’"),
                         userId,
                         businessId,
                         Identifier.random(),
@@ -186,7 +186,7 @@ handler = "messenger_test"
     assertThat(body.get("messages"))
         .hasSize(1)
         .allSatisfy(m -> assertThat(m.get("type").textValue()).isEqualTo("text"))
-        .allSatisfy(m -> assertThat(m.get("value").textValue()).isEqualTo("hello world!"))
+        .allSatisfy(m -> assertThat(m.get("value").textValue()).isEqualTo(ts.tail().message()))
         .allSatisfy(
             m ->
                 assertThat(m.get("timestamp").textValue())


### PR DESCRIPTION
memory store now has a new config option `message_history_length` to truncate the history when needed

additionally I added some test for unicode encoding/decoding