### PR TITLE
Adding a defaultCredentialsProvider for AWS S3

### DIFF
--- a/src/main/java/com/meta/cp4m/S3PreProcessor.java
+++ b/src/main/java/com/meta/cp4m/S3PreProcessor.java
@@ -47,16 +47,16 @@ public class S3PreProcessor<T extends Message> implements PreProcessor<T> {
     this.bucket = bucket;
     this.textMessageAddition = textMessageAddition;
 
-    @Nullable StaticCredentialsProvider staticCredentialsProvider;
+    @Nullable StaticCredentialsProvider staticCredentials;
     if (!this.awsAccessKeyID.isEmpty() && !this.awsSecretAccessKey.isEmpty()) {
       AwsSessionCredentials sessionCredentials =
               AwsSessionCredentials.create(this.awsAccessKeyID, this.awsSecretAccessKey, "");
-      staticCredentialsProvider = StaticCredentialsProvider.create(sessionCredentials);
+      staticCredentials = StaticCredentialsProvider.create(sessionCredentials);
     } else {
-      staticCredentialsProvider = null;
+      staticCredentials = null;
     }
 
-    this.credentials = Objects.requireNonNullElse(staticCredentialsProvider, DefaultCredentialsProvider.create());
+    this.credentials = Objects.requireNonNullElse(staticCredentials, DefaultCredentialsProvider.create());
   }
 
   @Override

--- a/src/main/java/com/meta/cp4m/S3PreProcessor.java
+++ b/src/main/java/com/meta/cp4m/S3PreProcessor.java
@@ -64,10 +64,10 @@ public class S3PreProcessor<T extends Message> implements PreProcessor<T> {
 
     switch (in.tail().payload()) {
       case Payload.Image i -> {
-        this.sendRequest(i.value(), in.userId().toString(), i.extension(), this.credentials);
+        this.sendRequest(i.value(), in.userId().toString(), i.extension());
       }
       case Payload.Document i -> {
-        this.sendRequest(i.value(), in.userId().toString(), i.extension(), this.credentials);
+        this.sendRequest(i.value(), in.userId().toString(), i.extension());
       }
       default -> {
         return in;
@@ -83,12 +83,12 @@ public class S3PreProcessor<T extends Message> implements PreProcessor<T> {
                 Identifier.random())); // TODO: remove last message
   }
 
-  public void sendRequest(byte[] media, String senderID, String extension, AwsCredentialsProvider credentials) {
+  public void sendRequest(byte[] media, String senderID, String extension) {
     String key = senderID + '_' + Instant.now().toEpochMilli() + '.' + extension;
     try (S3Client s3Client =
         S3Client.builder()
             .region(Region.of(this.region))
-            .credentialsProvider(credentials)
+            .credentialsProvider(this.credentials)
             .build()) {
 
       PutObjectRequest request =

--- a/src/main/java/com/meta/cp4m/S3PreProcessorConfig.java
+++ b/src/main/java/com/meta/cp4m/S3PreProcessorConfig.java
@@ -18,8 +18,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public record S3PreProcessorConfig(
     String name,
-    String awsAccessKeyId,
-    String awsSecretAccessKey,
+    @Nullable String awsAccessKeyId,
+    @Nullable String awsSecretAccessKey,
     String region,
     String bucket,
     @Nullable String textMessageAddition)
@@ -30,8 +30,8 @@ public record S3PreProcessorConfig(
   @JsonCreator
   public S3PreProcessorConfig(
       @JsonProperty("name") String name,
-      @JsonProperty("aws_access_key_id") String awsAccessKeyId,
-      @JsonProperty("aws_secret_access_key") String awsSecretAccessKey,
+      @JsonProperty("aws_access_key_id") @Nullable String awsAccessKeyId,
+      @JsonProperty("aws_secret_access_key") @Nullable String awsSecretAccessKey,
       @JsonProperty("region") String region,
       @JsonProperty("bucket") String bucket,
       @JsonProperty("text_message_addition") @Nullable String textMessageAddition) {
@@ -41,10 +41,8 @@ public record S3PreProcessorConfig(
         "bucket does not match the aws region format(kebab case) or is empty");
 
     this.name = Objects.requireNonNull(name, "name is a required parameter");
-    this.awsAccessKeyId =
-        Objects.requireNonNull(awsAccessKeyId, "aws access key is a required parameter");
-    this.awsSecretAccessKey =
-        Objects.requireNonNull(awsSecretAccessKey, "aws secret access key is a required parameter");
+    this.awsAccessKeyId = Objects.requireNonNullElse(awsAccessKeyId, "");
+    this.awsSecretAccessKey = Objects.requireNonNullElse(awsSecretAccessKey, "");
     this.region = Objects.requireNonNull(region, "region is a required parameter");
     this.bucket = Objects.requireNonNull(bucket, "bucket is a required parameter");
     this.textMessageAddition = textMessageAddition;


### PR DESCRIPTION
Since setting up an EC2 instance and loading it with CP4M image would be time consuming, I have manually tested the flow.

Test Cases:
1. Existing flow with aws credentials in **local config file**
Result: Works as before

2. To simulate AWS EC2 instance-like credential behavior, the test uses a specific item in the AWS SDK credentials provider chain: the **credentials file** located in the **local .aws folder**. This file occupies the fourth position in the chain. The credentials provided by IAM roles attached to EC2 instances are positioned sixth in this chain
Result: Works by picking the credentials from **credentials** file

3. To test a fail case when using defaultCredentialsProvider, deleted the credentials from **credentials** file in .aws
Result: S3 Client fails with an error `Unable to load credentials from any of the providers in the chain AwsCredentialsProviderChain` as expected